### PR TITLE
Code style changes

### DIFF
--- a/Announcements.csproj
+++ b/Announcements.csproj
@@ -131,12 +131,12 @@
     <None Include="Resources\announcements_512_smT_icon.ico" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="packages\Fody.6.0.0\build\Fody.targets" Condition="Exists('packages\Fody.6.0.0\build\Fody.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('packages\Fody.6.0.0\build\Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Fody.6.0.0\build\Fody.targets'))" />
     <Error Condition="!Exists('packages\Costura.Fody.4.1.0\build\Costura.Fody.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Costura.Fody.4.1.0\build\Costura.Fody.props'))" />
+    <Error Condition="!Exists('packages\Fody.6.1.1\build\Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Fody.6.1.1\build\Fody.targets'))" />
   </Target>
+  <Import Project="packages\Fody.6.1.1\build\Fody.targets" Condition="Exists('packages\Fody.6.1.1\build\Fody.targets')" />
 </Project>

--- a/Program.cs
+++ b/Program.cs
@@ -1,20 +1,20 @@
-﻿using System.Configuration;
-using System.Collections.Specialized;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using System;
 using System.Windows.Forms;
 
-namespace Announcements {
-    static class Program {
+namespace Announcements
+{
+    internal static class Program
+    {
         /// <summary>
         /// The main entry point for the application.
         /// </summary>
         [STAThread]
-        static void Main() {
+        private static void Main()
+        {
             Application.EnableVisualStyles();
+
             Application.SetCompatibleTextRenderingDefault(false);
+
             Application.Run(new Announcements());
         }
     }

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following

--- a/UserInterface.Designer.cs
+++ b/UserInterface.Designer.cs
@@ -1,16 +1,24 @@
-﻿namespace Announcements {
-    partial class Announcements {
+﻿using System.ComponentModel;
+using System.Windows.Forms;
+using MetroFramework.Controls;
+
+namespace Announcements
+{
+    partial class Announcements
+    {
         /// <summary>
         /// Required designer variable.
         /// </summary>
-        private System.ComponentModel.IContainer components = null;
+        private IContainer components = null;
 
         /// <summary>
         /// Clean up any resources being used.
         /// </summary>
         /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
-        protected override void Dispose(bool disposing) {
-            if (disposing && (components != null)) {
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
                 components.Dispose();
             }
             base.Dispose(disposing);
@@ -22,7 +30,8 @@
         /// Required method for Designer support - do not modify
         /// the contents of this method with the code editor.
         /// </summary>
-        private void InitializeComponent() {
+        private void InitializeComponent()
+        {
             this.uxOpenFileDialog = new System.Windows.Forms.OpenFileDialog();
             this.uxSaveFileDialog = new System.Windows.Forms.SaveFileDialog();
             this.uxVersionLabel = new MetroFramework.Controls.MetroLabel();
@@ -45,9 +54,9 @@
             this.uxGitHubOutputBox = new MetroFramework.Controls.MetroTextBox();
             this.uxGitHubLabel = new MetroFramework.Controls.MetroLabel();
             this.SuspendLayout();
-            // 
+            //
             // uxVersionLabel
-            // 
+            //
             this.uxVersionLabel.AutoSize = true;
             this.uxVersionLabel.Location = new System.Drawing.Point(65, 60);
             this.uxVersionLabel.Name = "uxVersionLabel";
@@ -55,12 +64,12 @@
             this.uxVersionLabel.TabIndex = 15;
             this.uxVersionLabel.Text = "Version";
             this.uxVersionLabel.Theme = MetroFramework.MetroThemeStyle.Dark;
-            // 
+            //
             // uxVersionBox
-            // 
-            // 
-            // 
-            // 
+            //
+            //
+            //
+            //
             this.uxVersionBox.CustomButton.Image = null;
             this.uxVersionBox.CustomButton.Location = new System.Drawing.Point(125, 1);
             this.uxVersionBox.CustomButton.Name = "";
@@ -87,9 +96,9 @@
             this.uxVersionBox.UseSelectable = true;
             this.uxVersionBox.WaterMarkColor = System.Drawing.Color.FromArgb(((int)(((byte)(109)))), ((int)(((byte)(109)))), ((int)(((byte)(109)))));
             this.uxVersionBox.WaterMarkFont = new System.Drawing.Font("Segoe UI", 12F, System.Drawing.FontStyle.Italic, System.Drawing.GraphicsUnit.Pixel);
-            // 
+            //
             // uxUpdateTitleLabel
-            // 
+            //
             this.uxUpdateTitleLabel.AutoSize = true;
             this.uxUpdateTitleLabel.Location = new System.Drawing.Point(295, 60);
             this.uxUpdateTitleLabel.Name = "uxUpdateTitleLabel";
@@ -97,12 +106,12 @@
             this.uxUpdateTitleLabel.TabIndex = 17;
             this.uxUpdateTitleLabel.Text = "Update Title";
             this.uxUpdateTitleLabel.Theme = MetroFramework.MetroThemeStyle.Dark;
-            // 
+            //
             // uxUpdateTitleBox
-            // 
-            // 
-            // 
-            // 
+            //
+            //
+            //
+            //
             this.uxUpdateTitleBox.CustomButton.Image = null;
             this.uxUpdateTitleBox.CustomButton.Location = new System.Drawing.Point(172, 1);
             this.uxUpdateTitleBox.CustomButton.Name = "";
@@ -128,9 +137,9 @@
             this.uxUpdateTitleBox.UseSelectable = true;
             this.uxUpdateTitleBox.WaterMarkColor = System.Drawing.Color.FromArgb(((int)(((byte)(109)))), ((int)(((byte)(109)))), ((int)(((byte)(109)))));
             this.uxUpdateTitleBox.WaterMarkFont = new System.Drawing.Font("Segoe UI", 12F, System.Drawing.FontStyle.Italic, System.Drawing.GraphicsUnit.Pixel);
-            // 
+            //
             // uxConvert
-            // 
+            //
             this.uxConvert.Location = new System.Drawing.Point(533, 33);
             this.uxConvert.Name = "uxConvert";
             this.uxConvert.Size = new System.Drawing.Size(446, 85);
@@ -139,9 +148,9 @@
             this.uxConvert.Theme = MetroFramework.MetroThemeStyle.Dark;
             this.uxConvert.UseSelectable = true;
             this.uxConvert.Click += new System.EventHandler(this.UxConvert_Click);
-            // 
+            //
             // uxClearButton
-            // 
+            //
             this.uxClearButton.Location = new System.Drawing.Point(1014, 33);
             this.uxClearButton.Name = "uxClearButton";
             this.uxClearButton.Size = new System.Drawing.Size(446, 85);
@@ -150,9 +159,9 @@
             this.uxClearButton.Theme = MetroFramework.MetroThemeStyle.Dark;
             this.uxClearButton.UseSelectable = true;
             this.uxClearButton.Click += new System.EventHandler(this.UxClearButton_Click);
-            // 
+            //
             // uxRawInput
-            // 
+            //
             this.uxRawInput.AutoSize = true;
             this.uxRawInput.Location = new System.Drawing.Point(134, 161);
             this.uxRawInput.Name = "uxRawInput";
@@ -160,9 +169,9 @@
             this.uxRawInput.TabIndex = 21;
             this.uxRawInput.Text = "Insert Text Here";
             this.uxRawInput.Theme = MetroFramework.MetroThemeStyle.Dark;
-            // 
+            //
             // uxDiscordOuputLabel
-            // 
+            //
             this.uxDiscordOuputLabel.AutoSize = true;
             this.uxDiscordOuputLabel.Location = new System.Drawing.Point(617, 161);
             this.uxDiscordOuputLabel.Name = "uxDiscordOuputLabel";
@@ -170,9 +179,9 @@
             this.uxDiscordOuputLabel.TabIndex = 22;
             this.uxDiscordOuputLabel.Text = "Discord Output";
             this.uxDiscordOuputLabel.Theme = MetroFramework.MetroThemeStyle.Dark;
-            // 
+            //
             // uxHTMLOutputLabel
-            // 
+            //
             this.uxHTMLOutputLabel.AutoSize = true;
             this.uxHTMLOutputLabel.Location = new System.Drawing.Point(1061, 161);
             this.uxHTMLOutputLabel.Name = "uxHTMLOutputLabel";
@@ -180,9 +189,9 @@
             this.uxHTMLOutputLabel.TabIndex = 23;
             this.uxHTMLOutputLabel.Text = "HTML Output";
             this.uxHTMLOutputLabel.Theme = MetroFramework.MetroThemeStyle.Dark;
-            // 
+            //
             // uxMySQLOutputLabel
-            // 
+            //
             this.uxMySQLOutputLabel.AutoSize = true;
             this.uxMySQLOutputLabel.Location = new System.Drawing.Point(1518, 161);
             this.uxMySQLOutputLabel.Name = "uxMySQLOutputLabel";
@@ -190,15 +199,15 @@
             this.uxMySQLOutputLabel.TabIndex = 24;
             this.uxMySQLOutputLabel.Text = "MySQL Output";
             this.uxMySQLOutputLabel.Theme = MetroFramework.MetroThemeStyle.Dark;
-            // 
+            //
             // uxRawInputBox
-            // 
-            this.uxRawInputBox.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left) 
+            //
+            this.uxRawInputBox.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom)
+            | System.Windows.Forms.AnchorStyles.Left)
             | System.Windows.Forms.AnchorStyles.Right)));
-            // 
-            // 
-            // 
+            //
+            //
+            //
             this.uxRawInputBox.CustomButton.Image = null;
             this.uxRawInputBox.CustomButton.Location = new System.Drawing.Point(12, 1);
             this.uxRawInputBox.CustomButton.Name = "";
@@ -225,12 +234,12 @@
             this.uxRawInputBox.UseSelectable = true;
             this.uxRawInputBox.WaterMarkColor = System.Drawing.Color.FromArgb(((int)(((byte)(109)))), ((int)(((byte)(109)))), ((int)(((byte)(109)))));
             this.uxRawInputBox.WaterMarkFont = new System.Drawing.Font("Segoe UI", 12F, System.Drawing.FontStyle.Italic, System.Drawing.GraphicsUnit.Pixel);
-            // 
+            //
             // uxDiscordOutputBox
-            // 
-            // 
-            // 
-            // 
+            //
+            //
+            //
+            //
             this.uxDiscordOutputBox.CustomButton.Image = null;
             this.uxDiscordOutputBox.CustomButton.Location = new System.Drawing.Point(12, 1);
             this.uxDiscordOutputBox.CustomButton.Name = "";
@@ -257,12 +266,12 @@
             this.uxDiscordOutputBox.UseSelectable = true;
             this.uxDiscordOutputBox.WaterMarkColor = System.Drawing.Color.FromArgb(((int)(((byte)(109)))), ((int)(((byte)(109)))), ((int)(((byte)(109)))));
             this.uxDiscordOutputBox.WaterMarkFont = new System.Drawing.Font("Segoe UI", 12F, System.Drawing.FontStyle.Italic, System.Drawing.GraphicsUnit.Pixel);
-            // 
+            //
             // uxHTMLOutputBox
-            // 
-            // 
-            // 
-            // 
+            //
+            //
+            //
+            //
             this.uxHTMLOutputBox.CustomButton.Image = null;
             this.uxHTMLOutputBox.CustomButton.Location = new System.Drawing.Point(12, 1);
             this.uxHTMLOutputBox.CustomButton.Name = "";
@@ -289,12 +298,12 @@
             this.uxHTMLOutputBox.UseSelectable = true;
             this.uxHTMLOutputBox.WaterMarkColor = System.Drawing.Color.FromArgb(((int)(((byte)(109)))), ((int)(((byte)(109)))), ((int)(((byte)(109)))));
             this.uxHTMLOutputBox.WaterMarkFont = new System.Drawing.Font("Segoe UI", 12F, System.Drawing.FontStyle.Italic, System.Drawing.GraphicsUnit.Pixel);
-            // 
+            //
             // uxMySQLOutputBox
-            // 
-            // 
-            // 
-            // 
+            //
+            //
+            //
+            //
             this.uxMySQLOutputBox.CustomButton.Image = null;
             this.uxMySQLOutputBox.CustomButton.Location = new System.Drawing.Point(224, 2);
             this.uxMySQLOutputBox.CustomButton.Name = "";
@@ -321,9 +330,9 @@
             this.uxMySQLOutputBox.UseSelectable = true;
             this.uxMySQLOutputBox.WaterMarkColor = System.Drawing.Color.FromArgb(((int)(((byte)(109)))), ((int)(((byte)(109)))), ((int)(((byte)(109)))));
             this.uxMySQLOutputBox.WaterMarkFont = new System.Drawing.Font("Segoe UI", 12F, System.Drawing.FontStyle.Italic, System.Drawing.GraphicsUnit.Pixel);
-            // 
+            //
             // uxOpenMenuButton
-            // 
+            //
             this.uxOpenMenuButton.Location = new System.Drawing.Point(1518, 33);
             this.uxOpenMenuButton.Name = "uxOpenMenuButton";
             this.uxOpenMenuButton.Size = new System.Drawing.Size(180, 37);
@@ -332,9 +341,9 @@
             this.uxOpenMenuButton.Theme = MetroFramework.MetroThemeStyle.Dark;
             this.uxOpenMenuButton.UseSelectable = true;
             this.uxOpenMenuButton.Click += new System.EventHandler(this.UxOpenMenuButton_Click);
-            // 
+            //
             // uxSaveAsMenuButton
-            // 
+            //
             this.uxSaveAsMenuButton.Location = new System.Drawing.Point(1518, 81);
             this.uxSaveAsMenuButton.Name = "uxSaveAsMenuButton";
             this.uxSaveAsMenuButton.Size = new System.Drawing.Size(180, 37);
@@ -343,9 +352,9 @@
             this.uxSaveAsMenuButton.Theme = MetroFramework.MetroThemeStyle.Dark;
             this.uxSaveAsMenuButton.UseSelectable = true;
             this.uxSaveAsMenuButton.Click += new System.EventHandler(this.UxSaveAsMenuButton_Click);
-            // 
+            //
             // uxDiscordCount
-            // 
+            //
             this.uxDiscordCount.AutoSize = true;
             this.uxDiscordCount.Location = new System.Drawing.Point(467, 604);
             this.uxDiscordCount.Name = "uxDiscordCount";
@@ -353,12 +362,12 @@
             this.uxDiscordCount.TabIndex = 32;
             this.uxDiscordCount.Text = "Character Count: 0/2000";
             this.uxDiscordCount.Theme = MetroFramework.MetroThemeStyle.Dark;
-            // 
+            //
             // uxGitHubOutputBox
-            // 
-            // 
-            // 
-            // 
+            //
+            //
+            //
+            //
             this.uxGitHubOutputBox.CustomButton.Image = null;
             this.uxGitHubOutputBox.CustomButton.Location = new System.Drawing.Point(244, 1);
             this.uxGitHubOutputBox.CustomButton.Name = "";
@@ -385,9 +394,9 @@
             this.uxGitHubOutputBox.UseSelectable = true;
             this.uxGitHubOutputBox.WaterMarkColor = System.Drawing.Color.FromArgb(((int)(((byte)(109)))), ((int)(((byte)(109)))), ((int)(((byte)(109)))));
             this.uxGitHubOutputBox.WaterMarkFont = new System.Drawing.Font("Segoe UI", 12F, System.Drawing.FontStyle.Italic, System.Drawing.GraphicsUnit.Pixel);
-            // 
+            //
             // uxGitHubLabel
-            // 
+            //
             this.uxGitHubLabel.AutoSize = true;
             this.uxGitHubLabel.Location = new System.Drawing.Point(1518, 393);
             this.uxGitHubLabel.Name = "uxGitHubLabel";
@@ -395,9 +404,9 @@
             this.uxGitHubLabel.TabIndex = 33;
             this.uxGitHubLabel.Text = "GitHub Output";
             this.uxGitHubLabel.Theme = MetroFramework.MetroThemeStyle.Dark;
-            // 
+            //
             // Announcements
-            // 
+            //
             this.AllowDrop = true;
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
@@ -431,27 +440,26 @@
         }
 
         #endregion
-        private System.Windows.Forms.OpenFileDialog uxOpenFileDialog;
-        private System.Windows.Forms.SaveFileDialog uxSaveFileDialog;
-        private MetroFramework.Controls.MetroLabel uxVersionLabel;
-        private MetroFramework.Controls.MetroTextBox uxVersionBox;
-        private MetroFramework.Controls.MetroLabel uxUpdateTitleLabel;
-        private MetroFramework.Controls.MetroTextBox uxUpdateTitleBox;
-        private MetroFramework.Controls.MetroButton uxConvert;
-        private MetroFramework.Controls.MetroButton uxClearButton;
-        private MetroFramework.Controls.MetroLabel uxRawInput;
-        private MetroFramework.Controls.MetroLabel uxDiscordOuputLabel;
-        private MetroFramework.Controls.MetroLabel uxHTMLOutputLabel;
-        private MetroFramework.Controls.MetroLabel uxMySQLOutputLabel;
-        private MetroFramework.Controls.MetroTextBox uxRawInputBox;
-        private MetroFramework.Controls.MetroTextBox uxDiscordOutputBox;
-        private MetroFramework.Controls.MetroTextBox uxHTMLOutputBox;
-        private MetroFramework.Controls.MetroTextBox uxMySQLOutputBox;
-        private MetroFramework.Controls.MetroButton uxOpenMenuButton;
-        private MetroFramework.Controls.MetroButton uxSaveAsMenuButton;
-        private MetroFramework.Controls.MetroLabel uxDiscordCount;
-        private MetroFramework.Controls.MetroTextBox uxGitHubOutputBox;
-        private MetroFramework.Controls.MetroLabel uxGitHubLabel;
+        private OpenFileDialog uxOpenFileDialog;
+        private SaveFileDialog uxSaveFileDialog;
+        private MetroLabel uxVersionLabel;
+        private MetroTextBox uxVersionBox;
+        private MetroLabel uxUpdateTitleLabel;
+        private MetroTextBox uxUpdateTitleBox;
+        private MetroButton uxConvert;
+        private MetroButton uxClearButton;
+        private MetroLabel uxRawInput;
+        private MetroLabel uxDiscordOuputLabel;
+        private MetroLabel uxHTMLOutputLabel;
+        private MetroLabel uxMySQLOutputLabel;
+        private MetroTextBox uxRawInputBox;
+        private MetroTextBox uxDiscordOutputBox;
+        private MetroTextBox uxHTMLOutputBox;
+        private MetroTextBox uxMySQLOutputBox;
+        private MetroButton uxOpenMenuButton;
+        private MetroButton uxSaveAsMenuButton;
+        private MetroLabel uxDiscordCount;
+        private MetroTextBox uxGitHubOutputBox;
+        private MetroLabel uxGitHubLabel;
     }
 }
-

--- a/UserInterface.cs
+++ b/UserInterface.cs
@@ -1,37 +1,41 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Configuration;
 using System.IO;
 using System.Text;
-using System.Threading;
 using System.Windows.Forms;
+using Announcements.Properties;
 using MetroFramework.Controls;
 using MetroFramework.Forms;
 
-namespace Announcements {
-    public partial class Announcements : MetroForm {
-        public Announcements() {
+namespace Announcements
+{
+    public partial class Announcements : MetroForm
+    {
+        public Announcements()
+        {
             InitializeComponent();
+
             // Set the project icon to the icon in the resources folder
-            this.Icon = Properties.Resources.icon;
-            
+            Icon = Resources.icon;
+
             bool discord = Convert.ToBoolean(ConfigurationManager.AppSettings.Get("show_discord_output"));
             bool html = Convert.ToBoolean(ConfigurationManager.AppSettings.Get("show_html_output"));
             bool mysql = Convert.ToBoolean(ConfigurationManager.AppSettings.Get("show_mysql_output"));
             bool github = Convert.ToBoolean(ConfigurationManager.AppSettings.Get("show_github_output"));
 
-            this.uxDiscordOuputLabel.Visible = discord;
-            this.uxDiscordCount.Visible = discord;
-            this.uxDiscordOutputBox.Visible = discord;
+            uxDiscordOuputLabel.Visible = discord;
+            uxDiscordCount.Visible = discord;
+            uxDiscordOutputBox.Visible = discord;
 
-            this.uxHTMLOutputBox.Visible = html;
-            this.uxHTMLOutputLabel.Visible = html;
+            uxHTMLOutputBox.Visible = html;
+            uxHTMLOutputLabel.Visible = html;
 
-            this.uxMySQLOutputBox.Visible = mysql;
-            this.uxMySQLOutputLabel.Visible = mysql;
+            uxMySQLOutputBox.Visible = mysql;
+            uxMySQLOutputLabel.Visible = mysql;
 
-            this.uxGitHubLabel.Visible = github;
-            this.uxGitHubOutputBox.Visible = github;
-
+            uxGitHubLabel.Visible = github;
+            uxGitHubOutputBox.Visible = github;
         }
 
         /// <summary>
@@ -39,7 +43,8 @@ namespace Announcements {
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        private void UxConvert_Click(object sender, EventArgs e) {
+        private void UxConvert_Click(object sender, EventArgs e)
+        {
             string[] list = uxRawInputBox.Text.Split('\n');
 
             uxDiscordOutputBox.Clear();
@@ -47,36 +52,10 @@ namespace Announcements {
             uxMySQLOutputBox.Clear();
             uxGitHubOutputBox.Clear();
 
-            OutputMySQL(list);
+            OutputMySql(list);
             OutputDiscord(list);
             OutputHtml(list);
             MarkdownFormat(uxGitHubOutputBox, list);
-        }
-
-        /// <summary>
-        /// Handles looping through the lines and generating the output
-        /// </summary>
-        /// <param name="list">The list of lines</param>
-        /// <param name="box">The box to modify the output of</param>
-        /// <param name="startText">The start text before headers</param>
-        /// <param name="endText">The end text after headers</param>
-        private void OutputMethod(string[] list, MetroTextBox box, string startText, string endText) {
-            for (int i = 0; i < list.Length; i++) {
-                string line = list[i];
-                if (string.IsNullOrWhiteSpace(line)) {
-                    Skip(box);
-                }
-                else {
-                    if (IsHeader(line)) {
-                        box.AppendText(startText + line + endText);
-                        Skip(box);
-                    }
-                    else {
-                        box.AppendText("- " + line);
-                        Skip(box);
-                    }
-                }
-            }
         }
 
         /// <summary>
@@ -84,19 +63,24 @@ namespace Announcements {
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        private void UxOpenMenuButton_Click(object sender, EventArgs e) {
-            if (uxOpenFileDialog.ShowDialog() == DialogResult.OK) {
+        private void UxOpenMenuButton_Click(object sender, EventArgs e)
+        {
+            if (uxOpenFileDialog.ShowDialog() == DialogResult.OK)
+            {
                 ClearAll();
-                try {
-                    string fn = @uxOpenFileDialog.FileName;
+                try
+                {
+                    string fn = uxOpenFileDialog.FileName;
                     string contents = File.ReadAllText(fn);
                     string[] split = contents.Split('~');
+
                     uxVersionBox.Text = split[0];
                     uxUpdateTitleBox.Text = split[1];
                     uxRawInputBox.Text = split[2];
                 }
-                catch (Exception ex) {
-                    sendError(ex);
+                catch (Exception ex)
+                {
+                    SendError(ex);
                 }
             }
         }
@@ -106,25 +90,21 @@ namespace Announcements {
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        private void UxSaveAsMenuButton_Click(object sender, EventArgs e) {
-            if (uxSaveFileDialog.ShowDialog() == DialogResult.OK) {
-                try {
+        private void UxSaveAsMenuButton_Click(object sender, EventArgs e)
+        {
+            if (uxSaveFileDialog.ShowDialog() == DialogResult.OK)
+            {
+                try
+                {
                     string fn = uxSaveFileDialog.FileName;
-                    string contents = uxVersionBox.Text + "~" + uxUpdateTitleBox.Text + "~" + uxRawInputBox.Text;
+                    string contents = $"{uxVersionBox.Text}~{uxUpdateTitleBox.Text}~{uxRawInputBox.Text}";
                     File.WriteAllText(fn, contents);
                 }
-                catch (Exception ex) {
-                    sendError(ex);
+                catch (Exception ex)
+                {
+                    SendError(ex);
                 }
             }
-        }
-
-        /// <summary>
-        /// Show a textbox to user containing error
-        /// </summary>
-        /// <param name="ex">The error that the user got</param>
-        private void sendError(Exception ex) {
-            MessageBox.Show("The following error occurred:" + ex.ToString());
         }
 
         /// <summary>
@@ -132,31 +112,16 @@ namespace Announcements {
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        private void UxClearButton_Click(object sender, EventArgs e) {
+        private void UxClearButton_Click(object sender, EventArgs e)
+        {
             ClearAll();
-        }
-
-        /// <summary>
-        /// Checks if a line is a header or not for outputs
-        /// </summary>
-        /// <param name="line"></param>
-        /// <returns></returns>
-        private bool IsHeader(string line) {
-            return line.Contains("Features") || line.Contains("Bug Fixes") || line.Contains("Changes") || line.Contains("Note") || line.Contains("Known Issues");
-        }
-
-        /// <summary>
-        /// Easy method to skip lines
-        /// </summary>
-        /// <param name="box"></param>
-        private void Skip(MetroTextBox box) {
-            box.AppendText(Environment.NewLine);
         }
 
         /// <summary>
         /// Clear all text boxes
         /// </summary>
-        private void ClearAll() {
+        private void ClearAll()
+        {
             uxVersionBox.Clear();
             uxUpdateTitleBox.Clear();
             uxRawInputBox.Clear();
@@ -171,7 +136,8 @@ namespace Announcements {
         /// </summary>
         /// <param name="box">The box that is being outputted</param>
         /// <param name="list">Contents of the changelog</param>
-        private void MarkdownFormat(MetroTextBox box, string[] list) {
+        private void MarkdownFormat(MetroTextBox box, IEnumerable<string> list)
+        {
             box.AppendText("**UPDATE**");
             Skip(box);
             Skip(box);
@@ -186,22 +152,26 @@ namespace Announcements {
         /// Easy handling of creating the output for the mysql text box
         /// </summary>
         /// <param name="list">List of data</param>
-        private void OutputMySQL(string[] list) {
-            StringBuilder sb = new StringBuilder();
-            for (int i = 0; i < list.Length; i++) {
-                string line = list[i];
-                if (string.IsNullOrWhiteSpace(line)) {
+        private void OutputMySql(IEnumerable<string> list)
+        {
+            var sb = new StringBuilder();
+
+            foreach (string line in list)
+            {
+                if (string.IsNullOrWhiteSpace(line))
+                {
                     sb.Append("\\n");
                 }
-                else {
-                    if (IsHeader(line)) {
-                        sb.Append("&6&l" + line + "\\n");
-                    }
-                    else {
-                        sb.Append("&a- " + line + "\\n");
-                    }
+                else if (IsHeader(line))
+                {
+                    sb.Append($"&6&l{line}\\n");
+                }
+                else
+                {
+                    sb.Append($"&a- {line}\\n");
                 }
             }
+
             uxMySQLOutputBox.Text = sb.ToString();
         }
 
@@ -209,22 +179,90 @@ namespace Announcements {
         /// Easy handling of creating the output for the discord text box
         /// </summary>T
         /// <param name="list">List of data</param>
-        private void OutputDiscord(string[] list) {
+        private void OutputDiscord(IEnumerable<string> list)
+        {
             MarkdownFormat(uxDiscordOutputBox, list);
-            uxDiscordOutputBox.AppendText("**" + ConfigurationManager.AppSettings.Get("project_name") + " v" + uxVersionBox.Text + " is now live!**");
-            Skip(uxDiscordOutputBox);
-            uxDiscordOutputBox.AppendText("Plugin Page: " + ConfigurationManager.AppSettings.Get("project_page"));
 
-            uxDiscordCount.Text = "Character Count: " + Convert.ToString(uxDiscordOutputBox.Text.Length) + "/2000";
+            uxDiscordOutputBox.AppendText(
+                $"**{ConfigurationManager.AppSettings.Get("project_name")} v{uxVersionBox.Text} is now live!**");
+            Skip(uxDiscordOutputBox);
+
+            uxDiscordOutputBox.AppendText($"Plugin Page: {ConfigurationManager.AppSettings.Get("project_page")}");
+
+            uxDiscordCount.Text = $"Character Count: {Convert.ToString(uxDiscordOutputBox.Text.Length)}/2000";
         }
 
         /// <summary>
         /// Easy handling of creating the output for the html text box
         /// </summary>
         /// <param name="list">List of data</param>
-        private void OutputHtml(string[] list) {
+        private void OutputHtml(IEnumerable<string> list)
+        {
             OutputMethod(list, uxHTMLOutputBox, "[B]", "[/B]");
             Skip(uxHTMLOutputBox);
+        }
+
+        /// <summary>
+        /// Handles looping through the lines and generating the output
+        /// </summary>
+        /// <param name="list">The list of lines</param>
+        /// <param name="box">The box to modify the output of</param>
+        /// <param name="startText">The start text before headers</param>
+        /// <param name="endText">The end text after headers</param>
+        private static void OutputMethod(IEnumerable<string> list, MetroTextBox box, string startText, string endText)
+        {
+            foreach (string line in list)
+            {
+                if (string.IsNullOrWhiteSpace(line))
+                {
+                    Skip(box);
+                }
+                else
+                {
+                    if (IsHeader(line))
+                    {
+                        box.AppendText(startText + line + endText);
+                        Skip(box);
+                    }
+                    else
+                    {
+                        box.AppendText($"- {line}");
+                        Skip(box);
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Show a textbox to user containing error
+        /// </summary>
+        /// <param name="ex">The error that the user got</param>
+        private static void SendError(Exception ex)
+        {
+            MessageBox.Show($"The following error occurred:{ex}");
+        }
+
+        /// <summary>
+        /// Checks if a line is a header or not for outputs
+        /// </summary>
+        /// <param name="line"></param>
+        /// <returns></returns>
+        private static bool IsHeader(string line)
+        {
+            return line.Contains("Features") ||
+                   line.Contains("Bug Fixes") ||
+                   line.Contains("Changes") ||
+                   line.Contains("Note") ||
+                   line.Contains("Known Issues");
+        }
+
+        /// <summary>
+        /// Easy method to skip lines
+        /// </summary>
+        /// <param name="box"></param>
+        private static void Skip(MetroTextBox box)
+        {
+            box.AppendText(Environment.NewLine);
         }
     }
 }

--- a/packages.config
+++ b/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Costura.Fody" version="4.1.0" targetFramework="net472" />
-  <package id="Fody" version="6.0.0" targetFramework="net472" developmentDependency="true" />
+  <package id="Fody" version="6.1.1" targetFramework="net472" developmentDependency="true" />
   <package id="MetroModernUI" version="1.4.0.0" targetFramework="net472" />
 </packages>


### PR DESCRIPTION
Most of these changes are based on Resharper/Visual Studio lints. Most of these come down to personal preference in the end, but I think there are justifications for most of the lints. Feel free to offer suggestions or change things!

In no particular order:
Removed unneeded imports
Removed unneeded `this`
Followed C# naming conventions
Made certain methods `static` that could be made so
Moved `static` methods to the bottom of the class
Converted `for` loops to `foreach` when able
Made most methods accept the more generic `IEnumerable<string>` where appropriate
Made `IsHeader` easier to read (could arguably make a method for this to make the code more DRY)
Updated Fody dependency
Added explicit `internal`/`private` modifiers